### PR TITLE
Fix VPCZoneIdentifier and update pause time format

### DIFF
--- a/asg-v2.cfndsl.rb
+++ b/asg-v2.cfndsl.rb
@@ -135,7 +135,7 @@ CloudFormation do
     DesiredCapacity Ref(:AsgDesired)
     MinSize Ref(:AsgMin)
     MaxSize Ref(:AsgMax)
-    VPCZoneIdentifier Ref(:SubnetIds)
+    VPCZoneIdentifiers Ref(:SubnetIds)
     LaunchTemplate({
       LaunchTemplateId: Ref(:LaunchTemplate),
       Version: FnGetAtt(:LaunchTemplate, :LatestVersionNumber)

--- a/asg-v2.config.yaml
+++ b/asg-v2.config.yaml
@@ -15,7 +15,7 @@ asg_update_policy:
     - AZRebalance
     - AlarmNotification
     - ScheduledActions
-  pause_time: PT0
+  pause_time: PT0S
   wait_on_signals: 'false'
 
 iam_policies:


### PR DESCRIPTION
VPCZoneIdentifier is always an array
fix pause time format in update policy
